### PR TITLE
fix [flex-01] centre the div as stated in 1st exercise

### DIFF
--- a/flex/01-flex-center/style.css
+++ b/flex/01-flex-center/style.css
@@ -3,6 +3,9 @@
   border: 4px solid midnightblue;
   width: 400px;
   height: 300px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .box {


### PR DESCRIPTION
made the container a flex container and then used 'justify-content: center' to center the div on the primary axis and 'align-items: center' to center the div on the cross axis.

![image](https://github.com/user-attachments/assets/75b00e97-fdfa-4483-a6d2-0ffe81ed1b49)
